### PR TITLE
Remove config from image

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - .github/workflows/build-containers.yml
-      - ./Dockerfile
+      - Dockerfile
     workflow_dispatch:
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,9 @@ RUN set -x \
     && popd \
     && rm -rf slurm \
     && groupadd -r --gid=990 slurm \
-    && useradd -r -g slurm --uid=990 slurm \
-    && mkdir /etc/sysconfig/slurm \
+    && useradd -r -g slurm --uid=990 slurm
+
+RUN mkdir /etc/sysconfig/slurm \
         /var/spool/slurmd \
         /var/run/slurmd \
         /var/run/slurmdbd \
@@ -81,17 +82,9 @@ RUN set -x \
         /var/lib/slurmd/qos_usage \
         /var/lib/slurmd/fed_mgr_state \
     && chown -R slurm:slurm /var/*/slurm* \
-    && chown -R slurm:slurm /etc/slurm \
-    && chmod -R 600 /etc/slurm \
     && /sbin/create-munge-key
 
-#COPY slurm.conf /etc/slurm/slurm.conf
-#COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
-#RUN set -x \
-#    && chown slurm:slurm /etc/slurm/slurmdbd.conf \
-#    && chmod 600 /etc/slurm/slurmdbd.conf
-
-
+VOLUME /etc/slurm
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,11 +85,11 @@ RUN set -x \
     && chown -R slurm:slurm /var/*/slurm* \
     && /sbin/create-munge-key
 
-COPY slurm.conf /etc/slurm/slurm.conf
-COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
-RUN set -x \
-    && chown slurm:slurm /etc/slurm/slurmdbd.conf \
-    && chmod 600 /etc/slurm/slurmdbd.conf
+#COPY slurm.conf /etc/slurm/slurm.conf
+#COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
+#RUN set -x \
+#    && chown slurm:slurm /etc/slurm/slurmdbd.conf \
+#    && chmod 600 /etc/slurm/slurmdbd.conf
 
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,6 @@ RUN set -x \
     && ./configure --enable-debug --prefix=/usr --sysconfdir=/etc/slurm \
         --with-mysql_config=/usr/bin  --libdir=/usr/lib64 \
     && make install \
-#    && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
-#    && install -D -m644 etc/slurm.conf.example /etc/slurm/slurm.conf.example \
-#    && install -D -m644 etc/slurmdbd.conf.example /etc/slurm/slurmdbd.conf.example \
     && install -D -m644 contribs/slurm_completion_help/slurm_completion.sh /etc/profile.d/slurm_completion.sh \
     && popd \
     && rm -rf slurm \
@@ -85,6 +82,7 @@ RUN set -x \
         /var/lib/slurmd/fed_mgr_state \
     && chown -R slurm:slurm /var/*/slurm* \
     && chown -R slurm:slurm /etc/slurm \
+    && chmod -R 600 /etc/slurm \
     && /sbin/create-munge-key
 
 #COPY slurm.conf /etc/slurm/slurm.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ RUN set -x \
     && ./configure --enable-debug --prefix=/usr --sysconfdir=/etc/slurm \
         --with-mysql_config=/usr/bin  --libdir=/usr/lib64 \
     && make install \
-    && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
-    && install -D -m644 etc/slurm.conf.example /etc/slurm/slurm.conf.example \
-    && install -D -m644 etc/slurmdbd.conf.example /etc/slurm/slurmdbd.conf.example \
+#    && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
+#    && install -D -m644 etc/slurm.conf.example /etc/slurm/slurm.conf.example \
+#    && install -D -m644 etc/slurmdbd.conf.example /etc/slurm/slurmdbd.conf.example \
     && install -D -m644 contribs/slurm_completion_help/slurm_completion.sh /etc/profile.d/slurm_completion.sh \
     && popd \
     && rm -rf slurm \
@@ -73,6 +73,7 @@ RUN set -x \
         /var/lib/slurmd \
         /var/log/slurm \
         /data \
+        /etc/slurm \
     && touch /var/lib/slurmd/node_state \
         /var/lib/slurmd/front_end_state \
         /var/lib/slurmd/job_state \
@@ -83,6 +84,7 @@ RUN set -x \
         /var/lib/slurmd/qos_usage \
         /var/lib/slurmd/fed_mgr_state \
     && chown -R slurm:slurm /var/*/slurm* \
+    && chown -R slurm:slurm /etc/slurm \
     && /sbin/create-munge-key
 
 #COPY slurm.conf /etc/slurm/slurm.conf

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The compose file will run the following containers:
 The compose file will create the following named volumes:
 
 * etc_munge         ( -> /etc/munge     )
-* etc_slurm         ( -> /etc/slurm     )
 * slurm_jobdir      ( -> /data          )
 * var_lib_mysql     ( -> /var/lib/mysql )
 * var_log_slurm     ( -> /var/log/slurm )
@@ -37,19 +36,12 @@ tag:
 docker build --build-arg SLURM_TAG="slurm-19-05-2-1" -t slurm-docker-cluster:19.05.2 .
 ```
 
-Or equivalently using `docker-compose`:
-
-```console
-SLURM_TAG=slurm-19-05-2-1 IMAGE_TAG=19.05.2 docker-compose build
-```
-
-
 ## Starting the Cluster
 
 Run `docker-compose` to instantiate the cluster:
 
 ```console
-IMAGE_TAG=19.05.2 docker-compose up -d
+docker compose up -d
 ```
 
 ## Register the Cluster with SlurmDBD
@@ -101,8 +93,8 @@ slurm-2.out
 ## Stopping and Restarting the Cluster
 
 ```console
-docker-compose stop
-docker-compose start
+docker compose stop
+docker compose start
 ```
 
 ## Deleting the Cluster
@@ -110,7 +102,5 @@ docker-compose start
 To remove all containers and volumes, run:
 
 ```console
-docker-compose stop
-docker-compose rm -f
-docker volume rm slurm-docker-cluster_etc_munge slurm-docker-cluster_etc_slurm slurm-docker-cluster_slurm_jobdir slurm-docker-cluster_var_lib_mysql slurm-docker-cluster_var_log_slurm
+./rm-cluster
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - var_lib_mysql:/var/lib/mysql
 
   slurmdbd:
-    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
+    image: slurm-docker-cluster:${IMAGE_TAG:-e41370d}
     build:
       context: .
       args:
@@ -33,7 +33,7 @@ services:
       - mysql
 
   slurmctld:
-    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
+    image: slurm-docker-cluster:${IMAGE_TAG:-e41370d}
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -48,7 +48,7 @@ services:
       - "slurmdbd"
 
   c1:
-    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
+    image: slurm-docker-cluster:${IMAGE_TAG:-e41370d}
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -63,7 +63,7 @@ services:
       - "slurmctld"
 
   c2:
-    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
+    image: slurm-docker-cluster:${IMAGE_TAG:-e41370d}
     command: ["slurmd"]
     hostname: c2
     container_name: c2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       context: .
       args:
         SLURM_TAG: ${SLURM_TAG:-slurm-23.02}
+    #command: sh -c "set -x && chown slurm:slurm /etc/slurm/slurmdbd.conf && chmod 600 /etc/slurm/slurmdbd.conf && slurmdbd
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -26,6 +27,8 @@ services:
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6819"
     depends_on:
@@ -41,6 +44,8 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6817"
     depends_on:
@@ -56,6 +61,8 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:
@@ -71,6 +78,8 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,11 @@ services:
       context: .
       args:
         SLURM_TAG: ${SLURM_TAG:-slurm-23.02}
-    #command: sh -c "set -x && chown slurm:slurm /etc/slurm/slurmdbd.conf && chmod 600 /etc/slurm/slurmdbd.conf && slurmdbd
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
       - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
@@ -41,11 +39,9 @@ services:
     hostname: slurmctld
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
-      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6817"
     depends_on:
@@ -58,11 +54,9 @@ services:
     container_name: c1
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
-      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:
@@ -75,11 +69,9 @@ services:
     container_name: c2
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
-      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:
@@ -87,7 +79,6 @@ services:
 
 volumes:
   etc_munge:
-  etc_slurm:
   slurm_jobdir:
   var_lib_mysql:
   var_log_slurm:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 if [ "$1" = "slurmdbd" ]
 then
@@ -8,6 +8,8 @@ then
 
     echo "---> Starting the Slurm Database Daemon (slurmdbd) ..."
 
+    chown slurm:slurm /etc/slurm/slurmdbd.conf
+    chmod 600 /etc/slurm/slurmdbd.conf
     {
         . /etc/slurm/slurmdbd.conf
         until echo "SELECT 1" | mysql -h $StorageHost -u$StorageUser -p$StoragePass 2>&1 > /dev/null

--- a/rm-cluster
+++ b/rm-cluster
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose stop
+docker compose rm -f
+docker volume rm \
+    slurm-docker-cluster_etc_munge \
+    slurm-docker-cluster_slurm_jobdir \
+    slurm-docker-cluster_var_lib_mysql \
+    slurm-docker-cluster_var_log_slurm


### PR DESCRIPTION
- Removes etc_slurm named volume as unnecessary
- Mount slurm.conf and slurmdbd.conf in from host
- Note slurmdbd.conf has to be mounted in rw, then the entrypoint script chmods it to slurm inside the container.
- Tested that you can change slurm.conf on the host, then run scontrol reconfigure inside e.g. slurmctld, and changes are propagated to slurmds