### PR TITLE
Fix nfs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This generates a set of secrets. If these need to be regenerated, see "Reconfigu
 
 A ReadWriteMany (RWX) volume is required, if a named volume exists, set `nfs.claimName` in the `values.yaml` file to its name. If not, manifests to deploy a Rook NFS volume are provided in the `/nfs` directory. You can deploy this by running
 ```console
-/nfs/deploy-nfs.sh
+./nfs/deploy-nfs.sh
 ```
 and leaving `nfs.claimName` as the provided value.
 

--- a/nfs/deploy-nfs.sh
+++ b/nfs/deploy-nfs.sh
@@ -3,9 +3,9 @@
 # Based on https://rook.io/docs/nfs/v1.7/quickstart.html
 # Manifests listed explicitly here to guarantee ordering
 
-kubectl create -f crds.yaml
-kubectl create -f operator.yaml
-kubectl create -f rbac.yaml
-kubectl create -f nfs.yaml
-kubectl create -f sc.yaml
-kubectl create -f pvc.yaml
+kubectl create -f nfs/crds.yaml
+kubectl create -f nfs/operator.yaml
+kubectl create -f nfs/rbac.yaml
+kubectl create -f nfs/nfs.yaml
+kubectl create -f nfs/sc.yaml
+kubectl create -f nfs/pvc.yaml


### PR DESCRIPTION
Fixes issues with Rook setup:
- Path in README for rook setup script is wrong
- Shell script assumes you've cd'd into `nfs/` which isn't in the instructions and is undesirable anyway.