### PR TITLE
Feat/autoscale hostnetwork

### DIFF
--- a/slurm-cluster-chart/files/slurm.conf
+++ b/slurm-cluster-chart/files/slurm.conf
@@ -48,8 +48,7 @@ AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=slurmdbd
 AccountingStoragePort=6819
 #
-SlurmctldParameters=cloud_dns,cloud_reg_addrs,idle_on_node_suspend
-CommunicationParameters=NoAddrCache
+SlurmctldParameters=cloud_reg_addrs,idle_on_node_suspend
 ReconfigFlags=KeepPowerSaveSettings
 #ResumeFailProgram=TODO?
 ResumeProgram=/usr/local/bin/k8s-slurmd-create

--- a/slurm-cluster-chart/files/slurm.conf
+++ b/slurm-cluster-chart/files/slurm.conf
@@ -49,6 +49,7 @@ AccountingStorageHost=slurmdbd
 AccountingStoragePort=6819
 #
 SlurmctldParameters=cloud_reg_addrs,idle_on_node_suspend
+CommunicationParameters=NoAddrCache
 ReconfigFlags=KeepPowerSaveSettings
 #ResumeFailProgram=TODO?
 ResumeProgram=/usr/local/bin/k8s-slurmd-create

--- a/slurm-cluster-chart/files/slurm.conf
+++ b/slurm-cluster-chart/files/slurm.conf
@@ -63,7 +63,7 @@ TreeWidth=65533
 
 # NODES
 MaxNodeCount=10
-NodeName=slurmd-[0-9] State=CLOUD
+NodeName=slurmd-[0-9] State=CLOUD CPUs=4
 
 # PARTITIONS
 PartitionName=all Default=yes Nodes=ALL

--- a/slurm-cluster-chart/templates/slurmd-template-configmap.yaml
+++ b/slurm-cluster-chart/templates/slurmd-template-configmap.yaml
@@ -33,6 +33,7 @@ data:
           name: slurmd
           ports:
             - containerPort: 6818
+              hostPort: 6818
           resources: {}
           volumeMounts:
             - mountPath: /etc/slurm/

--- a/slurm-cluster-chart/templates/slurmd-template-configmap.yaml
+++ b/slurm-cluster-chart/templates/slurmd-template-configmap.yaml
@@ -27,6 +27,8 @@ data:
             - slurmd
             - -b
             - -vvvvv
+            - -N
+            - SLURMD_NODENAME
           image: {{ .Values.slurmImage }}
           name: slurmd
           ports:
@@ -42,6 +44,8 @@ data:
               subPath: munge.key
           securityContext:
             privileged: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       dnsConfig:
         searches:
           - slurmd.default.svc.cluster.local


### PR DESCRIPTION
TODO: Do get pods in dns as soon as K8s launches them, so review cloud_dns, address caching, and whatever the caveat about aliases was for dynamic nodes (if relevant)?