### PR TITLE
Only permit one slurmd pod per k8s node

### DIFF
--- a/slurm-cluster-chart/templates/slurmd.yaml
+++ b/slurm-cluster-chart/templates/slurmd.yaml
@@ -20,14 +20,6 @@ spec:
         app.kubernetes.io/name: slurm
         app.kubernetes.io/component: slurmd
     spec:
-      topologySpreadConstraints:
-        - maxSkew: 1
-          whenUnsatisfiable: ScheduleAnyway
-          topologyKey: kubernetes.io/hostname
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: slurm
-              app.kubernetes.io/component: slurmd
       containers:
         - args:
             - slurmd
@@ -37,6 +29,7 @@ spec:
           name: slurmd
           ports:
             - containerPort: 6818
+              hostPort:  6818
           resources: {}
           volumeMounts:
             - mountPath: /etc/slurm/


### PR DESCRIPTION
Replaces the skewconstraint with a hostPort, so can only schedule one slurmd pod per k8s node.