### PR TITLE
Replaced mounted kubeconfig with service account

### DIFF
--- a/generate-secrets.sh
+++ b/generate-secrets.sh
@@ -11,6 +11,3 @@ kubectl create secret generic munge-key-secret \
 --from-literal=munge.key=$(dd if=/dev/urandom bs=1 count=1024 2>/dev/null | base64 -w 0) \
 -o yaml | \
 kubectl apply -f -
-
-cp $KUBECONFIG slurm-cluster-chart/files/kubeconfig
-echo "copied $KUBECONFIG into slurm-cluster-chart/files/"

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -9,6 +9,8 @@ LABEL org.opencontainers.image.source="https://github.com/stackhpc/slurm-docker-
 ARG SLURM_TAG=slurm-23.02
 ARG GOSU_VERSION=1.11
 
+COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+
 RUN set -ex \
     && yum makecache \
     && yum -y update \
@@ -42,6 +44,7 @@ RUN set -ex \
        hwloc-devel \
        openssh-server \
        apptainer \
+       kubectl \
     && yum clean all \
     && rm -rf /var/cache/yum
 
@@ -90,9 +93,6 @@ RUN mkdir /etc/sysconfig/slurm \
     && chown -R slurm:slurm /var/*/slurm* \
     && useradd -u 1000 rocky \
     && usermod -p '*' rocky # unlocks account but sets no password
-
-COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
-RUN dnf install -y kubectl
 
 VOLUME /etc/slurm
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -51,10 +51,6 @@ then
     echo "---> Setting ownership for state directory ..."
     chown slurm:slurm /var/spool/slurmctld
 
-    echo "---> Copying Kubeconfig ..."
-    install -o slurm -g slurm -m u=rwX,go= -d /var/lib/slurmctld/
-    install -o slurm -g slurm -m u=r,go= /tmp/kubeconfig /var/lib/slurmctld/
-
     echo "---> Starting the Slurm Controller Daemon (slurmctld) ..."
     if /usr/sbin/slurmctld -V | grep -q '17.02' ; then
         exec gosu slurm /usr/sbin/slurmctld -D "${@:2}"

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -10,6 +10,9 @@ echo "Powering up hosts: $hosts" >> /var/log/slurm/power_save.log
 for host in $hosts
 do
    echo "Creating $host" >> /var/log/slurm/power_save.log
-   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | tee /dev/tty | kubectl create -f - | tee /dev/tty
+   touch tmpfile.yml
+   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml > tmpfile.yml
+   echo "sed successful" >> /var/log/slurm/power_save.log
+   kubectl create -f tmpfile.yml &> /var/log/slurm/power_save.log
    echo "done" >> /var/log/slurm/power_save.log
 done

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -10,6 +10,6 @@ echo "Powering up hosts: $hosts" >> /var/log/slurm/power_save.log
 for host in $hosts
 do
    echo "Creating $host" >> /var/log/slurm/power_save.log
-   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f -
+   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f - >> /var/log/slurm/power_save.log
    echo "done" >> /var/log/slurm/power_save.log
 done

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -10,6 +10,6 @@ echo "Powering up hosts: $hosts" >> /var/log/slurm/power_save.log
 for host in $hosts
 do
    echo "Creating $host" >> /var/log/slurm/power_save.log
-   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f - >> /var/log/slurm/power_save.log
+   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f - || echo "kubectl error" >> /var/log/slurm/power_save.log
    echo "done" >> /var/log/slurm/power_save.log
 done

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -2,13 +2,15 @@
 
 echo "$(date) Resume invoked $0 $*" &>> /var/log/slurm/power_save.log
 
-echo "Arguments: $* $0 $1" &>> /var/log/slurm/power_save.log
+APISERVER=https://kubernetes.default.svc
+SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
+NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+TOKEN=$(cat ${SERVICEACCOUNT}/token)
+CACERT=${SERVICEACCOUNT}/ca.crt
 
 hosts=$(scontrol show hostnames $1) # this is purely a textual expansion, doens't depend on defined nodes
-echo "Powering up hosts: $hosts" &>> /var/log/slurm/power_save.log
 for host in $hosts
 do
-   echo "Creating $host" &>> /var/log/slurm/power_save.log
-   ( sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f - ) &>> /var/log/slurm/power_save.log
-   echo "done" &>> /var/log/slurm/power_save.log
+   ( sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | \
+   kubectl --server $APISERVER --token $TOKEN --certificate-authority $CACERT create -f - )
 done

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -1,7 +1,5 @@
 #!/usr/bin/bash
 
-export KUBECONFIG=/var/lib/slurmctld/kubeconfig
-
 echo "$(date) Resume invoked $0 $*" >> /var/log/slurm/power_save.log
 
 hosts=$(scontrol show hostnames $1) # this is purely a textual expansion, doens't depend on defined nodes

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -10,6 +10,6 @@ echo "Powering up hosts: $hosts" >> /var/log/slurm/power_save.log
 for host in $hosts
 do
    echo "Creating $host" >> /var/log/slurm/power_save.log
-   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f - || echo "kubectl error" >> /var/log/slurm/power_save.log
+   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | tee /dev/tty | kubectl create -f - | tee /dev/tty
    echo "done" >> /var/log/slurm/power_save.log
 done

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -euo pipefail
 
 echo "$(date) Resume invoked $0 $*" >> /var/log/slurm/power_save.log
 

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -3,8 +3,13 @@ set -euo pipefail
 
 echo "$(date) Resume invoked $0 $*" >> /var/log/slurm/power_save.log
 
+echo "Arguments: $* $0 $1"
+
 hosts=$(scontrol show hostnames $1) # this is purely a textual expansion, doens't depend on defined nodes
+echo "Powering up hosts: $hosts"
 for host in $hosts
 do
+   echo "Creating $host"
    sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f -
+   echo "done"
 done

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -1,18 +1,14 @@
 #!/usr/bin/bash
-set -euo pipefail
 
-echo "$(date) Resume invoked $0 $*" >> /var/log/slurm/power_save.log
+echo "$(date) Resume invoked $0 $*" &>> /var/log/slurm/power_save.log
 
-echo "Arguments: $* $0 $1" >> /var/log/slurm/power_save.log
+echo "Arguments: $* $0 $1" &>> /var/log/slurm/power_save.log
 
 hosts=$(scontrol show hostnames $1) # this is purely a textual expansion, doens't depend on defined nodes
-echo "Powering up hosts: $hosts" >> /var/log/slurm/power_save.log
+echo "Powering up hosts: $hosts" &>> /var/log/slurm/power_save.log
 for host in $hosts
 do
-   echo "Creating $host" >> /var/log/slurm/power_save.log
-   touch tmpfile.yml
-   sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml > tmpfile.yml
-   echo "sed successful" >> /var/log/slurm/power_save.log
-   kubectl create -f tmpfile.yml &> /var/log/slurm/power_save.log
-   echo "done" >> /var/log/slurm/power_save.log
+   echo "Creating $host" &>> /var/log/slurm/power_save.log
+   ( sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f - ) &>> /var/log/slurm/power_save.log
+   echo "done" &>> /var/log/slurm/power_save.log
 done

--- a/image/k8s-slurmd-create
+++ b/image/k8s-slurmd-create
@@ -3,13 +3,13 @@ set -euo pipefail
 
 echo "$(date) Resume invoked $0 $*" >> /var/log/slurm/power_save.log
 
-echo "Arguments: $* $0 $1"
+echo "Arguments: $* $0 $1" >> /var/log/slurm/power_save.log
 
 hosts=$(scontrol show hostnames $1) # this is purely a textual expansion, doens't depend on defined nodes
-echo "Powering up hosts: $hosts"
+echo "Powering up hosts: $hosts" >> /var/log/slurm/power_save.log
 for host in $hosts
 do
-   echo "Creating $host"
+   echo "Creating $host" >> /var/log/slurm/power_save.log
    sed s/SLURMD_NODENAME/$host/ /etc/slurm/slurmd-pod-template.yml | kubectl create -f -
-   echo "done"
+   echo "done" >> /var/log/slurm/power_save.log
 done

--- a/image/k8s-slurmd-delete
+++ b/image/k8s-slurmd-delete
@@ -1,10 +1,15 @@
 #!/usr/bin/bash
-set -euo pipefail
 
 echo "$(date) Suspend invoked $0 $*" >> /var/log/slurm/power_save.log
+
+APISERVER=https://kubernetes.default.svc
+SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
+NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+TOKEN=$(cat ${SERVICEACCOUNT}/token)
+CACERT=${SERVICEACCOUNT}/ca.crt
 
 hosts=$(scontrol show hostnames $1) # this is purely a textual expansion, doens't depend on defined nodes
 for host in $hosts
 do
-   kubectl delete pod $host
+   kubectl --server $APISERVER --token $TOKEN --certificate-authority $CACERT delete pod $host
 done

--- a/image/k8s-slurmd-delete
+++ b/image/k8s-slurmd-delete
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -euo pipefail
 
 echo "$(date) Suspend invoked $0 $*" >> /var/log/slurm/power_save.log
 

--- a/image/k8s-slurmd-delete
+++ b/image/k8s-slurmd-delete
@@ -1,7 +1,5 @@
 #!/usr/bin/bash
 
-export KUBECONFIG=/var/lib/slurmctld/kubeconfig
-
 echo "$(date) Suspend invoked $0 $*" >> /var/log/slurm/power_save.log
 
 hosts=$(scontrol show hostnames $1) # this is purely a textual expansion, doens't depend on defined nodes

--- a/slurm-cluster-chart/templates/kubeconfig.yml
+++ b/slurm-cluster-chart/templates/kubeconfig.yml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubeconfig-secret
-data:
-  kubeconfig: |
-    {{- .Files.Get "files/kubeconfig" | b64enc | nindent 4 -}}
-    

--- a/slurm-cluster-chart/templates/slurm-autoscaler-service-account.yaml
+++ b/slurm-cluster-chart/templates/slurm-autoscaler-service-account.yaml
@@ -13,7 +13,7 @@ metadata:
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
-  verbs: ["get","apply","create", "patch", "delete" ]
+  verbs: ["get","apply","create", "patch", "delete", "list", "watch"]
 
 ---
 

--- a/slurm-cluster-chart/templates/slurm-autoscaler-service-account.yaml
+++ b/slurm-cluster-chart/templates/slurm-autoscaler-service-account.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: slurm-autoscaler-account
+automountServiceAccountToken: True
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: slurm-autoscaler-role
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get","apply","create", "patch", "delete" ]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: slurm-autoscaler-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: slurm-autoscaler-account
+roleRef:
+  kind: Role
+  name: slurm-autoscaler-role
+  apiGroup: rbac.authorization.k8s.io

--- a/slurm-cluster-chart/templates/slurmctld-statefulset.yaml
+++ b/slurm-cluster-chart/templates/slurmctld-statefulset.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: slurm
         app.kubernetes.io/component: slurmctld
     spec:
+      serviceAccountName: slurm-autoscaler-account
       containers:
         - args:
             - slurmctld
@@ -38,9 +39,6 @@ spec:
               subPath: munge.key
             - mountPath: /var/spool/slurmctld
               name: slurmctld-state
-            - mountPath: /tmp/kubeconfig
-              name: kubeconfig-secret
-              subPath: kubeconfig
       dnsConfig:
         searches:
           - slurmd.default.svc.cluster.local
@@ -62,8 +60,4 @@ spec:
         - name: munge-key-secret
           secret:
             secretName: {{ .Values.secrets.mungeKey }}
-            defaultMode: 0400
-        - name: kubeconfig-secret
-          secret:
-            secretName: kubeconfig-secret
             defaultMode: 0400

--- a/slurm-cluster-chart/values.yaml
+++ b/slurm-cluster-chart/values.yaml
@@ -1,4 +1,4 @@
-slurmImage: ghcr.io/stackhpc/slurm-docker-cluster:9e4598e
+slurmImage: ghcr.io/stackhpc/slurm-docker-cluster:a731c60
 
 replicas:
   slurmd: 2


### PR DESCRIPTION
Now uses a ServiceAccount with minimal permissions for power up/down scripts, which automatically mounts an API token for kubectl to use. The token is has a default expiration time of an hour but my understanding is that it gets refreshed, just need to test if it works after an hour
Recommend a squash merge, lots of useless image rebuilds in this